### PR TITLE
remove redundant rollback

### DIFF
--- a/tests/Aggregator.Tests/Command/CommandProcessorTests.cs
+++ b/tests/Aggregator.Tests/Command/CommandProcessorTests.cs
@@ -263,7 +263,6 @@ namespace Aggregator.Tests.Command
             eventStoreMock.Verify(x => x.BeginTransaction(It.IsAny<CommandHandlingContext>()), Times.Once);
 
             transactionMock.Verify(x => x.Commit(), Times.Never);
-            transactionMock.Verify(x => x.Rollback(), Times.Once);
             transactionMock.Verify(x => x.Dispose(), Times.Once);
         }
 
@@ -299,7 +298,6 @@ namespace Aggregator.Tests.Command
             eventStoreMock.Verify(x => x.BeginTransaction(It.IsAny<CommandHandlingContext>()), Times.Once);
 
             transactionMock.Verify(x => x.Commit(), Times.Never);
-            transactionMock.Verify(x => x.Rollback(), Times.Once);
             transactionMock.Verify(x => x.Dispose(), Times.Once);
         }
 

--- a/tests/Aggregator.Tests/Command/CommandProcessorTests.cs
+++ b/tests/Aggregator.Tests/Command/CommandProcessorTests.cs
@@ -263,6 +263,7 @@ namespace Aggregator.Tests.Command
             eventStoreMock.Verify(x => x.BeginTransaction(It.IsAny<CommandHandlingContext>()), Times.Once);
 
             transactionMock.Verify(x => x.Commit(), Times.Never);
+            transactionMock.Verify(x => x.Rollback(), Times.Never);
             transactionMock.Verify(x => x.Dispose(), Times.Once);
         }
 
@@ -298,6 +299,7 @@ namespace Aggregator.Tests.Command
             eventStoreMock.Verify(x => x.BeginTransaction(It.IsAny<CommandHandlingContext>()), Times.Once);
 
             transactionMock.Verify(x => x.Commit(), Times.Never);
+            transactionMock.Verify(x => x.Rollback(), Times.Never);
             transactionMock.Verify(x => x.Dispose(), Times.Once);
         }
 


### PR DESCRIPTION
when using a transaction pattern, it is my preference to omit the try catch and let the dispose do the rollback for an non-committed things